### PR TITLE
Need Sprockets for building my app assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 
 gem "middleman", "~>4.0"
 gem "middleman-livereload"
+gem "middleman-sprockets", "~> 4.0.0.rc.1"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
+    middleman-sprockets (4.0.0.rc.1)
+      middleman-core (>= 4.0.0.rc.1)
+      sprockets (~> 3.0)
     mime-types (3.0)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2015.1120)
@@ -100,6 +103,8 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     sass (3.4.21)
+    sprockets (3.4.1)
+      rack (> 1, < 3)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -117,6 +122,7 @@ PLATFORMS
 DEPENDENCIES
   middleman (~> 4.0)
   middleman-livereload
+  middleman-sprockets (~> 4.0.0.rc.1)
   rake
 
 BUNDLED WITH


### PR DESCRIPTION
Noticed the JS wasn't running because the `//=require shoestring` line wasn't getting converted to actually including the line. Forgot that Middleman 4 doesn't include `middleman-sprockets` by default any more. This PR fixes it.